### PR TITLE
Move the decorator "Program" node traversal into the visitor itself.

### DIFF
--- a/src/transforms/DecoratorImportTransform.js
+++ b/src/transforms/DecoratorImportTransform.js
@@ -58,18 +58,13 @@ module.exports = class DecoratorImporter {
 
     /**
      * Automatically import decorators referenced from this file, matching the provided definitions.
-     * Traverse each decorator via the Program node to ensure that this plugin runs in a deterministic order.
      */
-    traverseProgram(path) {
-        path.traverse({
-            'ClassExpression|ClassDeclaration|ClassProperty|Method': (path) => {
-                if (path.node.decorators) {
-                    path.node.decorators.forEach((decorator, index) => {
-                        this.visitDecorator(path.get('decorators.' + index), path);
-                    });
-                }
-            },
-        });
+    apply(path) {
+        if (path.node.decorators) {
+            path.node.decorators.forEach((decorator, index) => {
+                this.visitDecorator(path.get('decorators.' + index), path);
+            });
+        }
     }
 
     /** Sanity-check the syntax of decorator import definitions. */


### PR DESCRIPTION
This pulls out the `traverseProgram` helper from `DecoratorImportTransform` into the visitor itself, so that it's explicit which nodes are being traversed from the visitor object. I'm doing this here because in `transform-react-twist` we need to run multiple transforms on the Program node, and I want to traverse them simultaneously. (Other PR incoming.)