### PR TITLE
Bug fix: hasThisContext only returns true for class methods, so we don't try to hoist in non-class functions

### DIFF
--- a/src/PathUtils.js
+++ b/src/PathUtils.js
@@ -100,7 +100,7 @@ module.exports = class PathUtils {
 
     /**
      * Test whether "this" is defined for the given path - we walk up the parent functions, until we find a
-     * function that's not an arrow function (in which case this is defined), or we hit the program (in which
+     * class method (in which case this is defined), or we hit the program (in which
      * case it isn't).
      *
      * @param {Path} path
@@ -110,10 +110,13 @@ module.exports = class PathUtils {
         if (!path || path.isProgram()) {
             return false;
         }
-        if (path.isFunction() && !path.isArrowFunctionExpression()) {
+        if (path.isClassMethod()) {
             return true;
         }
-        return PathUtils.hasThisContext(path.getFunctionParent());
+        if (!path.isFunction() || path.isArrowFunctionExpression()) {
+            return PathUtils.hasThisContext(path.getFunctionParent());
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

See https://github.com/adobe/babel-plugin-transform-react-twist/issues/14

Note that tests are in the PR for babel-plugin-transform-react-twist: https://github.com/adobe/babel-plugin-transform-react-twist/pull/20

### Checklist

- [ ] I've read the [contribution guidelines](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [ ] An issue has been created for this PR
- [ ] Title begins with one of the following: `Fix:`, `Update:`, `Breaking:`, or `New:`
- [ ] Title ends with a reference to the related issue(s): `(fixes #issue)` or `(refs #issue)`
- [ ] Linting and unit tests all pass (`npm test`)
- [ ] PR includes new unit tests as necessary (or will be submitted as a separate PR)
- [ ] PR includes documentation as necessary (or will be forthcoming in a separate PR)
